### PR TITLE
Improve tuning and cv evaluation with improved projection matrix

### DIFF
--- a/R/tuning.R
+++ b/R/tuning.R
@@ -122,20 +122,22 @@ tuning_AICc <-
   function(Y, K_mat, lambda) {
     
     n <- nrow(K_mat)
-    K1 <- cbind(1, K_mat)
-    K2 <- cbind(0, rbind(0, K_mat))
+    # K1 <- cbind(1, K_mat)
+    # K2 <- cbind(0, rbind(0, K_mat))
     CV <- sapply(lambda, function(k) {
       
-      A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
+      # A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
       # A_kernel_only <- K_mat %*% ginv(K_mat + k * diag(n))
-      
+      proj_matrix <- 
+        estimate_ridge(X = matrix(1, nrow = n, ncol = 1),
+                       K = K_mat, Y = Y, lambda = k)$proj_matrix
+      A <- proj_matrix$total
       log(t(Y) %*% (diag(n) - A) %*% (diag(n) - A) %*% Y) +
         2 * (tr(A) + 2) / (n - tr(A) - 3)
     })
     
     lambda[which(CV == min(CV))]
   }
-
 
 
 #' Calculating Tuning Parameters Using GCVc
@@ -179,12 +181,16 @@ tuning_GCVc <-
   function(Y, K_mat, lambda) {
     
     n <- nrow(K_mat)
-    K1 <- cbind(1, K_mat)
-    K2 <- cbind(0, rbind(0, K_mat))
+    # K1 <- cbind(1, K_mat)
+    # K2 <- cbind(0, rbind(0, K_mat))
     CV <- sapply(lambda, function(k) {
       
-      A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
+      # A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
       # A_kernel_only <- K_mat %*% ginv(K_mat + k * diag(n))
+      proj_matrix <- 
+        estimate_ridge(X = matrix(1, nrow = n, ncol = 1),
+                       K = K_mat, Y = Y, lambda = k)$proj_matrix      
+      A <- proj_matrix$total
       
       log(t(Y) %*% (diag(n) - A) %*% (diag(n) - A) %*% Y) -
         2 * log(max(0, 1 - tr(A) / n - 2 / n))
@@ -236,15 +242,18 @@ tuning_gmpml <-
   function(Y, K_mat, lambda) {
     
     n <- nrow(K_mat)
-    K1 <- cbind(1, K_mat)
-    K2 <- cbind(0, rbind(0, K_mat))
+    # K1 <- cbind(1, K_mat)
+    # K2 <- cbind(0, rbind(0, K_mat))
     CV <- sapply(lambda, function(k){
       
-      A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
+      # A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
       A_kernel_only <- K_mat %*% ginv(K_mat + k * diag(n))
       log_det <- unlist(determinant(diag(n) - A_kernel_only), 
                         use.names = FALSE)[1]
-      
+      proj_matrix <- 
+        estimate_ridge(X = matrix(1, nrow = n, ncol = 1),
+                       K = K_mat, Y = Y, lambda = k)$proj_matrix      
+      A <- proj_matrix$total
       log(t(Y) %*% (diag(n) - A) %*% Y) - 1 / (n - 1) * log_det
     })
     
@@ -295,12 +304,11 @@ tuning_loocv <-
   function(Y, K_mat, lambda) {
     
     n <- nrow(K_mat)
-    K1 <- cbind(1, K_mat)
-    K2 <- cbind(0, rbind(0, K_mat))
     CV <- sapply(lambda, function(k) {
-      
-      A <- K1 %*% ginv(t(K1) %*% K1 + k * K2) %*% t(K1)
-      # A_kernel_only <- K_mat %*% ginv(K_mat + k * diag(n))
+      proj_matrix <- 
+        estimate_ridge(X = matrix(1, nrow = n, ncol = 1),
+                       K = K_mat, Y = Y, lambda = k)$proj_matrix      
+      A <- proj_matrix$total
       
       sum(((diag(n) - A) %*% Y / diag(diag(n) - A)) ^ 2)
     })

--- a/R/util.R
+++ b/R/util.R
@@ -88,7 +88,7 @@ generate_formula <-
 #'
 #'
 #' data <- generate_data(n = 100, label_names =
-#' list(X1 = c("x1", "x2"), X2 = c("x3", "x4")),
+#' list(X1 = c("x1", "x2"), X2 = c("x3", "x4")),
 #' method = "rbf", int_effect = 0, l = 1, p = 2, eps = .01)
 #'
 #'


### PR DESCRIPTION
Added an improved estimation procedure `estimate_ridge` that uses proper projection matrix as shown [here](https://www.dropbox.com/s/4g1q9lkch8hcy06/Projection%20Matrix.pdf?dl=0), and replaced old  estimation routines for projection matrices in `estimate_base` and `tuning_*` functions with the new procedure.

Additional Changes:
1. Improved code modularity for function `estimation` by separating estimation procedures for ensemble hat matrix as an individual function (`ensemble_kernel_matrix`)

2. Correct a tiny typo for the docstring of `generate_data`.